### PR TITLE
Fix a memory leak

### DIFF
--- a/src/aur.c
+++ b/src/aur.c
@@ -137,6 +137,7 @@ void aur_pkg_free (aurpkg_t *pkg)
 	FREE (pkg->urlpath);
 	FREE (pkg->license);
 	FREE (pkg->maintainer);
+	FREE (pkg->pkgbase);
 	FREE (pkg);
 }
 


### PR DESCRIPTION
This patch fixes a memory leak in ```aur.c```. ```pkg->pkgbase``` is [allocated here](https://github.com/archlinuxfr/package-query/blob/master/src/aur.c#L416-420), but not free'd in ```aur_pkg_free()```.

Tested with: 
```
valgrind --leak-check=full ./src/package-query --aur-url "https://aur4.archlinux.org" -Aif "%u" package-query
```
Before:
```
==1378== 
==1378== HEAP SUMMARY:
==1378==     in use at exit: 342 bytes in 12 blocks
==1378==   total heap usage: 38,225 allocs, 38,213 frees, 2,841,826 bytes allocated
==1378== 
==1378== 14 bytes in 1 blocks are definitely lost in loss record 4 of 12
==1378==    at 0x4C29F90: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1378==    by 0x55650B9: strndup (in /usr/lib/libc-2.21.so)
==1378==    by 0x404868: json_string (aur.c:396)
==1378==    by 0x50AD5A8: ??? (in /usr/lib/libyajl.so.2.1.0)
==1378==    by 0x40413B: aur_json_parse (aur.c:492)
==1378==    by 0x40413B: aur_fetch (aur.c:535)
==1378==    by 0x4046E1: aur_request (aur.c:645)
==1378==    by 0x403D0A: main (package-query.c:542)
==1378== 
==1378== LEAK SUMMARY:
==1378==    definitely lost: 14 bytes in 1 blocks
==1378==    indirectly lost: 0 bytes in 0 blocks
==1378==      possibly lost: 0 bytes in 0 blocks
==1378==    still reachable: 328 bytes in 11 blocks
==1378==         suppressed: 0 bytes in 0 blocks
```
After:
```
==1630== 
==1630== HEAP SUMMARY:
==1630==     in use at exit: 328 bytes in 11 blocks
==1630==   total heap usage: 38,213 allocs, 38,202 frees, 2,841,538 bytes allocated
==1630== 
==1630== LEAK SUMMARY:
==1630==    definitely lost: 0 bytes in 0 blocks
==1630==    indirectly lost: 0 bytes in 0 blocks
==1630==      possibly lost: 0 bytes in 0 blocks
==1630==    still reachable: 328 bytes in 11 blocks
==1630==         suppressed: 0 bytes in 0 blocks
```