### PR TITLE
Avoid passing a NULL to strcasestr.

### DIFF
--- a/src/aur.c
+++ b/src/aur.c
@@ -600,9 +600,10 @@ static int aur_request (alpm_list_t **targets, int type)
 				for (t=alpm_list_next (*targets); t; t=alpm_list_next (t))
 				{
 					if (strcasestr (aur_pkg_get_name (p->data),
-					                t->data)==NULL &&
-					    strcasestr (aur_pkg_get_desc (p->data),
-						            t->data)==NULL)
+									t->data)==NULL &&
+						(aur_pkg_get_desc (p->data)==NULL ||
+						strcasestr (aur_pkg_get_desc (p->data),
+									t->data)==NULL))
 						match=0;
 				}
 				if (match)


### PR DESCRIPTION
Fix [issue-13](https://github.com/archlinuxfr/package-query/issues/13) and [yaourt issue-133](https://github.com/archlinuxfr/yaourt/issues/133).

Some packages have no description, strcasestr(NULL, ptr) will cause a core dump.
