### PR TITLE
Support querying git clone url

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,13 @@ AC_ARG_WITH(aur-url,
 	[AUR_BASE_URL=$withval], [AUR_BASE_URL=https://aur.archlinux.org])
 
 AC_SUBST(AUR_BASE_URL)
+
+AC_ARG_WITH(aur-ssh-login,
+	AS_HELP_STRING([--with-aur-ssh-login=username@hostname], [default to aur@aur.archlinux.org]),
+	[AUR_SSH_LOGIN=$withval], [AUR_SSH_LOGIN=aur@aur.archlinux.org])
+
+AC_SUBST(AUR_SSH_LOGIN)
+
 AC_CONFIG_FILES([src/Makefile
 doc/Makefile
 Makefile
@@ -78,6 +85,7 @@ ${PACKAGE_NAME}:
   Variable information:
     root working directory : ${ROOTDIR}
     aur base url           : ${AUR_BASE_URL}
+    aur ssh login          : ${AUR_SSH_LOGIN}
 "
 
 

--- a/doc/package-query.8
+++ b/doc/package-query.8
@@ -220,6 +220,7 @@ Format can contain:
 %D: denpends on
 %f: filename
 %F: package\*(Aqs files
+%g: package git repository clone URL
 %I: install script
 %i: AUR ID
 %l: local version

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,7 @@ DEFS = -DLOCALEDIR=\"@localedir@\" \
        -DROOTDIR=\"$(ROOTDIR)\" \
        -DDBPATH=\"$(dbpath)\" \
        -DAUR_BASE_URL=\"$(AUR_BASE_URL)\" \
+       -DAUR_SSH_LOGIN=\"$(AUR_SSH_LOGIN)\" \
 	   @DEFS@
 if USE_GIT_VERSION
 DEFS += -DGIT_VERSION=\"$(GIT_VERSION)\"

--- a/src/aur.h
+++ b/src/aur.h
@@ -34,6 +34,7 @@ typedef struct _aurpkg_t
 	char *desc;
 	char *url;
 	char *urlpath;
+	char *gitpath;
 	char *license;
 	unsigned int votes;
 	unsigned short outofdate;
@@ -56,6 +57,7 @@ const char * aur_pkg_get_version (const aurpkg_t * pkg);
 const char * aur_pkg_get_desc (const aurpkg_t * pkg);
 const char * aur_pkg_get_url (const aurpkg_t * pkg);
 const char * aur_pkg_get_urlpath (const aurpkg_t * pkg);
+const char * aur_pkg_get_gitpath (const aurpkg_t * pkg);
 const char * aur_pkg_get_license (const aurpkg_t * pkg);
 unsigned int aur_pkg_get_votes (const aurpkg_t * pkg);
 unsigned short aur_pkg_get_outofdate (const aurpkg_t * pkg);

--- a/src/package-query.c
+++ b/src/package-query.c
@@ -61,6 +61,7 @@ void cleanup (int ret)
 	FREELIST(targets);
 	FREE (config.arch);
 	FREE (config.aur_url);
+	FREE (config.aur_ssh_login);
 	FREE (config.configfile);
 	FREE (config.dbpath);
 	FREE (config.rootdir);
@@ -101,6 +102,7 @@ void init_config (const char *myname)
 	config.show_size = 0;
 	config.arch = NULL;
 	config.aur_url = strdup (AUR_BASE_URL);
+	config.aur_ssh_login = strdup (AUR_SSH_LOGIN);
 	config.configfile = strndup (CONFFILE, PATH_MAX);
 	strcpy (config.delimiter, " ");
 	config.dbpath = NULL;
@@ -254,6 +256,7 @@ int main (int argc, char **argv)
 		{"color",      no_argument,       0, 1014},
 		{"rsort",      required_argument, 0, 1015},
 		{"pkgbase",    no_argument,       0, 1016},
+		{"aur-ssh-login",	required_argument, 0, 1017},
 		{"version",    no_argument,       0, 'v'},
 
 		{0, 0, 0, 0}
@@ -428,6 +431,10 @@ int main (int argc, char **argv)
 				break;
 			case 1016: /* --pkgbase */
 				config.pkgbase = 1;
+				break;
+			case 1017: /* --aur-ssh-login */
+				FREE (config.aur_ssh_login);
+				config.aur_ssh_login = strdup (optarg);
 				break;
 			case 'u':
 				config.filter |= F_UPGRADES;

--- a/src/util.h
+++ b/src/util.h
@@ -119,6 +119,7 @@ typedef struct _aq_config
 	unsigned short updates;
 	char *arch;
 	char *aur_url;
+	char *aur_ssh_login;
 	char *configfile;
 	char delimiter[SEP_LEN];
 	char *dbpath;


### PR DESCRIPTION
This PR implements #11.

Instead of giving http(s) URLs, I print SSH URLs in this PR, as http(s) ones are read-only and SSH ones are writable with appropriate permissions.

For example:
```
$ ./src/package-query -Aif '%g' package-query
aur@aur.archlinux.org:/package-query.git
```

The resultant URL can be fed to ```git clone``` directly.