### PR TITLE
nameonly option

### DIFF
--- a/src/alpm-query.c
+++ b/src/alpm-query.c
@@ -387,7 +387,10 @@ int search_pkg (alpm_db_t *db, alpm_list_t *targets)
 	for(t = pkgs; t; t = alpm_list_next(t))
 	{
 		alpm_pkg_t *info = t->data;
-		if (!filter (info, config.filter)) continue;
+		if (!filter (info, config.filter) ||
+				(config.name_only &&
+				!does_name_contain_targets (targets, alpm_pkg_get_name (info))))
+			continue;
 		ret++;
 		print_or_add_result ((void *) info, R_ALPM_PKG);
 	}

--- a/src/aur.c
+++ b/src/aur.c
@@ -585,14 +585,17 @@ static int aur_request (alpm_list_t **targets, int type)
 			for (p=pkgs; p; p=alpm_list_next (p))
 			{
 				int match=1;
-				for (t=alpm_list_next (*targets); t; t=alpm_list_next (t))
-				{
-					if (strcasestr (aur_pkg_get_name (p->data),
-									t->data)==NULL &&
-						(aur_pkg_get_desc (p->data)==NULL ||
-						strcasestr (aur_pkg_get_desc (p->data),
-									t->data)==NULL))
-						match=0;
+				if (config.name_only) {
+					if (!does_name_contain_targets(*targets, aur_pkg_get_name (p->data)))
+						match = 0;
+				} else {
+					for (t=alpm_list_next (*targets); t; t=alpm_list_next (t))
+					{
+						if (strcasestr (aur_pkg_get_name (p->data), t->data)==NULL &&
+								(aur_pkg_get_desc (p->data)==NULL ||
+								strcasestr (aur_pkg_get_desc (p->data), t->data)==NULL))
+							match=0;
+					}
 				}
 				if (match)
 				{

--- a/src/package-query.c
+++ b/src/package-query.c
@@ -147,7 +147,7 @@ void usage (unsigned short _error)
 	fprintf(stderr, "\n\t-r --root <path>     default: %s", ROOTDIR);
 	fprintf(stderr, "\n\nModifiers:");
 	fprintf(stderr, "\n\t-i --info            search by name");
-	fprintf(stderr, "\n\t\t--pkgbase          limit info to pkgbase (AUR only)");
+	fprintf(stderr, "\n\t--pkgbase            limit info to pkgbase (AUR only)");
 	fprintf(stderr, "\n\t-l --list            list repository content");
 	fprintf(stderr, "\n\t-m --foreign         search for foreign packages");
 	fprintf(stderr, "\n\t-n --native          search for native packages");
@@ -157,6 +157,7 @@ void usage (unsigned short _error)
 	fprintf(stderr, "\n\t--qprovides          provides one of target");
 	fprintf(stderr, "\n\t--qreplaces          replaces one of target");
 	fprintf(stderr, "\n\t-s --search          search");
+	fprintf(stderr, "\n\t--nameonly           search in package names only");
 	fprintf(stderr, "\n\t-u --upgrades        list updates available");
 	fprintf(stderr, "\n\nFormats (man for more infos): ");
 	fprintf(stderr, "\n\ta: arch");
@@ -254,6 +255,7 @@ int main (int argc, char **argv)
 		{"color",      no_argument,       0, 1014},
 		{"rsort",      required_argument, 0, 1015},
 		{"pkgbase",    no_argument,       0, 1016},
+		{"nameonly",   no_argument,       0, 1017},
 		{"version",    no_argument,       0, 'v'},
 
 		{0, 0, 0, 0}
@@ -428,6 +430,9 @@ int main (int argc, char **argv)
 				break;
 			case 1016: /* --pkgbase */
 				config.pkgbase = 1;
+				break;
+			case 1017: /* --nameonly */
+				config.name_only = 1;
 				break;
 			case 'u':
 				config.filter |= F_UPGRADES;

--- a/src/util.c
+++ b/src/util.c
@@ -938,4 +938,16 @@ alpm_list_t *target_arg_close (target_arg_t *t, alpm_list_t *targets)
 	return targets;
 }
 
+int does_name_contain_targets (alpm_list_t *targets, const char *name)
+{
+	alpm_list_t *t;
+	for(t = targets; t; t = alpm_list_next(t)) {
+		const char *target = (const char *)(t->data);
+		if (strcasestr(name, target) == NULL) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
 /* vim: set ts=4 sw=4 noet: */

--- a/src/util.h
+++ b/src/util.h
@@ -117,6 +117,7 @@ typedef struct _aq_config
 	unsigned short query;
 	unsigned short show_size;
 	unsigned short updates;
+	unsigned short name_only;
 	char *arch;
 	char *aur_url;
 	char *configfile;
@@ -225,6 +226,9 @@ void show_results ();
 /* Utils */
 /* mbasename is from pacman's code */
 const char *mbasename(const char *path);
+
+/* Returns 1 if package name contains all targets; 0 otherwise */
+int does_name_contain_targets (alpm_list_t *targets, const char *name);
 
 #endif
 


### PR DESCRIPTION
Solution for issue #21 and archlinuxfr/yaourt#73

The solution introduces a new option for the search command (-s): --nameonly
This options works for all databases (local, sync, AUR) and allows to search for the given target(s) within the package names only. This solves the original yaourt issue with too many results returned for "rar" search; with this option, only the packages containing "rar" in their names will be returned.

TODO: maybe change the option to "--namesonly"? This is just a cosmetic change.