### PR TITLE
Use pkgbase in making git URLs

### DIFF
--- a/src/aur.c
+++ b/src/aur.c
@@ -698,12 +698,12 @@ const char *aur_get_str (void *p, unsigned char c)
 		case 'G':
 			info = (char *) malloc (sizeof (char) *
 				(strlen (config.aur_url) +
-				strlen (aur_pkg_get_name (pkg)) +
+				strlen (aur_pkg_get_pkgbase (pkg)) +
 				6 /* '/%s.git + \0 */
 			));
 			strcpy (info, config.aur_url);
 			strcat (info, "/");
-			strcat (info, aur_pkg_get_name (pkg));
+			strcat (info, aur_pkg_get_pkgbase (pkg));
 			strcat (info, ".git");
 			free_info = 1;
 			break;


### PR DESCRIPTION
For example, ```yaourt -S python2-click``` should clone ```https://aur.archlinux.org/python-click.git```. Sorry for not considering split packages when implementing this feature.