### PR TITLE
nameonly option: regex support

### DIFF
--- a/src/alpm-query.c
+++ b/src/alpm-query.c
@@ -389,7 +389,7 @@ int search_pkg (alpm_db_t *db, alpm_list_t *targets)
 		alpm_pkg_t *info = t->data;
 		if (!filter (info, config.filter) ||
 				(config.name_only &&
-				!does_name_contain_targets (targets, alpm_pkg_get_name (info))))
+				!does_name_contain_targets (targets, alpm_pkg_get_name (info), 1)))
 			continue;
 		ret++;
 		print_or_add_result ((void *) info, R_ALPM_PKG);

--- a/src/aur.c
+++ b/src/aur.c
@@ -586,7 +586,7 @@ static int aur_request (alpm_list_t **targets, int type)
 			{
 				int match=1;
 				if (config.name_only) {
-					if (!does_name_contain_targets(*targets, aur_pkg_get_name (p->data)))
+					if (!does_name_contain_targets (*targets, aur_pkg_get_name (p->data), 0))
 						match = 0;
 				} else {
 					for (t=alpm_list_next (*targets); t; t=alpm_list_next (t))

--- a/src/util.h
+++ b/src/util.h
@@ -228,7 +228,8 @@ void show_results ();
 const char *mbasename(const char *path);
 
 /* Returns 1 if package name contains all targets; 0 otherwise */
-int does_name_contain_targets (alpm_list_t *targets, const char *name);
+/* use_regex: 0 for AUR search, 1 for pacman search */
+int does_name_contain_targets (alpm_list_t *targets, const char *name, int use_regex);
 
 #endif
 


### PR DESCRIPTION
Regex support for the --nameonly option.
Works only for pacman db searches; AUR search does not support regexes anyway.