### PR TITLE
Fix unused-result warnings

### DIFF
--- a/src/alpm-query.c
+++ b/src/alpm-query.c
@@ -453,7 +453,10 @@ off_t alpm_pkg_get_realsize (alpm_pkg_t *pkg)
 	if (!files)
 		return 0;
 
-	chdir (alpm_option_get_root(config.handle));
+	int ret = chdir (alpm_option_get_root(config.handle));
+	if (ret != 0)
+		return 0;
+
 	CALLOC (inodes, files->count, sizeof (ino_t));
 	for (size_t k = 0; k < files->count; k++) {
 		const alpm_file_t *f = files->files + k;

--- a/src/util.c
+++ b/src/util.c
@@ -343,9 +343,9 @@ string_t *string_fcat (string_t *dest, const char *format, ...)
 	char *s;
 	va_list args;
 	va_start(args, format);
-	vasprintf(&s, format, args);
+	int ret = vasprintf(&s, format, args);
 	va_end(args);
-	if (!s) {
+	if (!s || ret < 0) {
 		perror ("vasprintf");
 		exit (1);
 	}
@@ -477,7 +477,10 @@ char *concat_backup_list (const alpm_list_t *backups)
 		const alpm_backup_t *backup = i->data;
 		if (backup) {
 			char *b_str;
-			asprintf (&b_str, "%s\t%s", backup->name, backup->hash);
+			int ret = asprintf (&b_str, "%s\t%s", backup->name, backup->hash);
+			if (!b_str || ret < 0) {
+				continue;
+			}
 			backups_str = alpm_list_add (backups_str, b_str);
 		}
 	}
@@ -525,14 +528,22 @@ static void print_escape (const char *str)
 char * itostr (int i)
 {
 	char *is;
-	asprintf (&is, "%d", i);
+	int ret = asprintf (&is, "%d", i);
+	if (ret < 0) {
+		FREE (is);
+		return NULL;
+	}
 	return is;
 }
 
 char * ltostr (long i)
 {
 	char *is;
-	asprintf (&is, "%ld", i);
+	int ret = asprintf (&is, "%ld", i);
+	if (ret < 0) {
+		FREE (is);
+		return NULL;
+	}
 	return is;
 }
 


### PR DESCRIPTION
Fixes the following warnings:
```
util.c: In function ‘string_fcat’:
util.c:346:2: warning: ignoring return value of ‘vasprintf’, declared with attribute warn_unused_result [-Wunused-result]
  vasprintf(&s, format, args);
  ^
util.c: In function ‘concat_backup_list’:
util.c:480:4: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
    asprintf (&b_str, "%s\t%s", backup->name, backup->hash);
    ^
util.c: In function ‘itostr’:
util.c:528:2: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
  asprintf (&is, "%d", i);
  ^
util.c: In function ‘ltostr’:
util.c:535:2: warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
  asprintf (&is, "%ld", i);
```