### PR TITLE
Recognize the AUR OutOfDate flag

### DIFF
--- a/src/aur.c
+++ b/src/aur.c
@@ -370,7 +370,7 @@ static int json_integer (void * ctx, long long val)
 			pkg_json->pkg->votes = (int) val;
 			break;
 		case AUR_OUT:
-			pkg_json->pkg->outofdate = (int) val;
+			pkg_json->pkg->outofdate = 1;
 			break;
 		case AUR_FIRST:
 			pkg_json->pkg->firstsubmit = (time_t) val;

--- a/src/util.c
+++ b/src/util.c
@@ -722,7 +722,7 @@ static void color_print_install_info (void *p, printpkgfn f, const char *lver, c
 static void color_print_aur_status (void *p, printpkgfn f)
 {
 	const char *info = f(p, 'o');
-	if (info && info[0] == '1') {
+	if (info && info[0] != '0') {
 		fprintf (stdout, " %s(%s)%s", color(C_OD), _("Out of Date"), color(C_NO));
 	}
 	info = f(p, 'w');
@@ -734,8 +734,8 @@ static void color_print_aur_status (void *p, printpkgfn f)
 static void color_print_package (void *p, printpkgfn f)
 {
 	static int number = 0;
-	const int aur = (f == aur_get_str);
-	const int grp = (f == alpm_grp_get_str);
+	const bool aur = (f == aur_get_str);
+	const bool grp = (f == alpm_grp_get_str);
 
 	/* Numbering list */
 	if (config.numbering) {


### PR DESCRIPTION
Fixes #68 
```
$ ./src/package-query -Ai freetype2-ubuntu
aur/freetype2-ubuntu 2.5.2-7 [installed] (Out of Date) (422)
```