### PR TITLE
libalpm now provides pkgbase info

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,8 @@ AC_CHECK_HEADERS([ctype.h getopt.h libintl.h limits.h locale.h sys/ioctl.h sys/u
 
 AC_CHECK_LIB([alpm], [alpm_version], ,
 	AC_MSG_ERROR([pacman is needed to compile package-query]))
+PKG_CHECK_MODULES([alpm], [libalpm >= 10.0.0])
+
 AC_CHECK_LIB([yajl], [yajl_free], ,
 	AC_MSG_ERROR([yajl is needed to compile package-query]))
 

--- a/doc/package-query.8
+++ b/doc/package-query.8
@@ -234,7 +234,7 @@ Format can contain:
 .\}
 .nf
 %a: architecture
-%b: base package (AUR)
+%b: base package
 %B: backups file
 %c: check dependencies (AUR)
 %C: conflicts with

--- a/src/alpm-query.c
+++ b/src/alpm-query.c
@@ -488,19 +488,21 @@ const char *alpm_pkg_get_str (void *p, unsigned char c)
 	info = NULL;
 	switch (c) {
 		case '2':
-			info = ltostr (alpm_pkg_get_isize(pkg));
+			info = ltostr (alpm_pkg_get_isize (pkg));
 			free_info = 1;
 			break;
 		case '5':
 			pkg = get_sync_pkg (pkg);
 			if (!pkg) break;
-			info = ltostr (alpm_pkg_download_size(pkg));
+			info = ltostr (alpm_pkg_download_size (pkg));
 			free_info = 1;
 			break;
 		case 'a':
 			info = (char *) alpm_pkg_get_arch (pkg);
 			break;
 		case 'b':
+			info = (char *) alpm_pkg_get_base (pkg);
+			break;
 		case 'B':
 			info = concat_backup_list (alpm_pkg_get_backup (pkg));
 			free_info = 1;


### PR DESCRIPTION
This commit will make `package-query` dependent on `pacman>=5.0`... is this ok?