### PR TITLE
string_ncat() optimization: realloc() calls

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -372,8 +372,12 @@ string_t *string_ncat (string_t *dest, const char *src, size_t n)
 		return dest;
 	}
 	if (dest->size <= dest->used + n) {
-		dest->size += ((n/PATH_MAX) + 1) * PATH_MAX;
-		/* dest->size += dest->used + n + 1; */
+		if (dest->used == 0) {
+			dest->size = PATH_MAX;
+		}
+		while (dest->size <= dest->used + n) {
+			dest->size *= 2;
+		}
 		REALLOC (dest->s, dest->size * sizeof (char));
 		if (dest->used == 0) dest->s[0] = '\0';
 	}


### PR DESCRIPTION
Decrease realloc() calls number by multiplying the allocated memory size by 2.
For a large output command, such as '-As rar', this allowed to decrease number of calls from 72 to 8.