### PR TITLE
Fix clang static analyzer warning

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -802,7 +802,7 @@ static void color_print_groups (const void *p, printpkgfn f)
 
 static void color_print_install_info (const void *p, printpkgfn f, const char *lver, const char *ver)
 {
-	if (lver) {
+	if (lver && ver) {
 		const char *info = f (p, 'r');
 		if (info && strcmp (info, "local") != 0) {
 			printf (" %s[%s", color(C_INSTALLED), _("installed"));


### PR DESCRIPTION
A possible use of null pointer has been identified by clang static
analyzer:

    ../src/util.c:809:8: warning: Null pointer passed as an argument to a 'nonnull' parameter
                            if (strcmp (ver, lver) != 0) {
                                ^~~~~~~~~~~~~~~~~~
    1 warning generated.

Add a `NULL` pointer check to fix the warning.