### PR TITLE
Add support for new functions of libalpm 11.0.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AC_CHECK_HEADERS([ctype.h getopt.h glob.h libintl.h limits.h locale.h regex.h si
 
 AC_CHECK_LIB([alpm], [alpm_version], ,
 	AC_MSG_ERROR([pacman is needed to compile package-query]))
-PKG_CHECK_MODULES([alpm], [libalpm >= 10.0.0])
+PKG_CHECK_MODULES([alpm], [libalpm >= 11.0.0])
 
 AC_CHECK_LIB([yajl], [yajl_free], ,
 	AC_MSG_ERROR([yajl is needed to compile package-query]))

--- a/doc/package-query.8
+++ b/doc/package-query.8
@@ -263,7 +263,7 @@ Format can contain:
 %l: local version
 %L: last submission (AUR)
 %m: maintainer or packager
-%M: make dependencies (AUR)
+%M: make dependencies (AUR and local package tarball)
 %n: name
 %N: required by (Needed by)
 %o: out of date (1 for true)

--- a/doc/package-query.8
+++ b/doc/package-query.8
@@ -247,7 +247,7 @@ Format can contain:
 %a: architecture
 %b: base package
 %B: backups file
-%c: check dependencies (AUR)
+%c: check dependencies (AUR and local package tarball)
 %C: conflicts with
 %d: description
 %D: depends on

--- a/src/alpm-query.c
+++ b/src/alpm-query.c
@@ -595,6 +595,13 @@ const char *alpm_pkg_get_str (const void *p, unsigned char c)
 		case 'm':
 			info = (char *) alpm_pkg_get_packager (pkg);
 			break;
+		case 'M':
+			if (alpm_pkg_get_origin (pkg) != ALPM_PKG_FROM_FILE) {
+				return NULL;
+			}
+			info = concat_dep_list (alpm_pkg_get_makedepends (pkg));
+			free_info = true;
+			break;
 		case 'n':
 			info = (char *) alpm_pkg_get_name (pkg);
 			break;

--- a/src/alpm-query.c
+++ b/src/alpm-query.c
@@ -559,6 +559,13 @@ const char *alpm_pkg_get_str (const void *p, unsigned char c)
 			info = concat_backup_list (alpm_pkg_get_backup (pkg));
 			free_info = true;
 			break;
+		case 'c':
+			if (alpm_pkg_get_origin (pkg) != ALPM_PKG_FROM_FILE) {
+				return NULL;
+			}
+			info = concat_dep_list (alpm_pkg_get_checkdepends (pkg));
+			free_info = true;
+			break;
 		case 'C':
 			info = concat_dep_list (alpm_pkg_get_conflicts (pkg));
 			free_info = true;


### PR DESCRIPTION
libalpm 11.0.0 brings `alpm_pkg_get_checkdepends()` and `alpm_pkg_get_makedepends()` for local package tarballs.

See: https://git.archlinux.org/pacman.git/commit/?id=0994893