### PR TITLE
Support building with Pacman 5.2 / libalpm 12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ AC_CHECK_HEADERS([ctype.h getopt.h glob.h libintl.h limits.h locale.h regex.h si
 AC_CHECK_LIB([alpm], [alpm_version], ,
 	AC_MSG_ERROR([pacman is needed to compile package-query]))
 PKG_CHECK_MODULES([alpm], [libalpm >= 11.0.0])
+AC_CHECK_FUNCS([alpm_sync_get_new_version])
 
 AC_CHECK_LIB([yajl], [yajl_free], ,
 	AC_MSG_ERROR([yajl is needed to compile package-query]))

--- a/src/alpm-query.c
+++ b/src/alpm-query.c
@@ -25,11 +25,16 @@
 #include <sys/utsname.h>
 #include <glob.h>
 
+#include "config.h"
 #include "util.h"
 #include "alpm-query.h"
 
 #define ARCH_PACKAGES_URL "https://www.archlinux.org/packages/"
 #define OUTOFDATE_FLAG "\"flag_date\": "
+
+#if HAVE_ALPM_SYNC_GET_NEW_VERSION
+#define alpm_sync_newversion alpm_sync_get_new_version
+#endif /* HAVE_ALPM_SYNC_GET_NEW_VERSION */
 
 typedef const char *(*retcharfn) (void *);
 


### PR DESCRIPTION
Add a check for the  alpm_sync_get_new_version()` function when configuring the build, which is basically the same as the old `alpm_sync_newversion()`, and use it when available.

This makes it possible to build `package-query` against libalpm 12, included as part of Pacman 5.2